### PR TITLE
Change grim screen shot options

### DIFF
--- a/wayfire.ini
+++ b/wayfire.ini
@@ -187,9 +187,9 @@ command_logout = wlogout
 # https://wayland.emersion.fr/grim/
 # https://wayland.emersion.fr/slurp/
 binding_screenshot = KEY_PRINT
-command_screenshot = grim $(date '+%F_%T').webp
+command_screenshot = grim $(date '+%F_%T').png
 binding_screenshot_interactive = <shift> KEY_PRINT
-command_screenshot_interactive = slurp | grim -g - $(date '+%F_%T').webp
+command_screenshot_interactive = slurp | grim -g - $(date '+%F_%T').png
 
 # Volume controls
 # https://alsa-project.org


### PR DESCRIPTION
Grim only saves png, jpeg, or ppm, and doesn't infer the type from the filename, so give it the correct extension for its default file type, PNG.